### PR TITLE
Improve homepage in gemspec

### DIFF
--- a/gem-gratitude.gemspec
+++ b/gem-gratitude.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "httparty"
   s.add_runtime_dependency "redcarpet"
   s.add_runtime_dependency "os", "~> 0.9"
-  s.homepage    = 'http://rubygems.org/gems/gem-gratitude'
+  s.homepage    = 'https://github.com/danbartlett/gem-gratitude'
   s.license     = 'MIT'
 end


### PR DESCRIPTION
Convention has become to reference the code repo in the gemspec homepage
